### PR TITLE
Optimized (copy) of "In Tranquil Spring" audio and made it somewhat loopable

### DIFF
--- a/Assets/Stuff Brandon Did.meta
+++ b/Assets/Stuff Brandon Did.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 5442d32af0e804a58922bb304568f9d8
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Stuff Brandon Did/In Tranquil Spring.ogg.meta
+++ b/Assets/Stuff Brandon Did/In Tranquil Spring.ogg.meta
@@ -1,0 +1,22 @@
+fileFormatVersion: 2
+guid: d4851f35e86b341ce9a22cf6674ae978
+AudioImporter:
+  externalObjects: {}
+  serializedVersion: 6
+  defaultSettings:
+    loadType: 2
+    sampleRateSetting: 1
+    sampleRateOverride: 44100
+    compressionFormat: 1
+    quality: 0.25
+    conversionMode: 0
+  platformSettingOverrides: {}
+  forceToMono: 0
+  normalize: 1
+  preloadAudioData: 1
+  loadInBackground: 0
+  ambisonic: 0
+  3D: 1
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
Don't be surprised! I am just helping for fun because this game is indeed amazing.

Took the "In Tranquil Spring" audio, created a copy and worked with the copy. You can find the copy in ```Assets/Stuff Brandon Did``` directory. I did not alter anything to Scene 1 because I don't want to cause merge conflicts with anyone else changing Scene 1.

I trimmed away the front silent part to reduce audible silence when looping. I also trimmed away the end so that after playing the last note, the
audio ends, making it loopable so that when playing from the start again, audio sounds continuous (not perfect however, but I tried my best).

Unfortunately, this is not easily loopable because instrumental effects like reverberation and sustain will not carry over, which will cause the start to sound abrupt when coming from the end.

I then exported the audio using Audacity and in .ogg format. The audio is then further tweaked in Unity so that its load type is "streaming" instead of "decompress on load", which will take up more space when decompressing the music. The quality of the music is reduced, which in turn reduces size of the file. Most people shouldn't hear the quality loss though.